### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/ServiceStatus.Core.AspNet.Hybrid/ServiceStatus.Core.AspNet.Hybrid.csproj
+++ b/src/ServiceStatus.Core.AspNet.Hybrid/ServiceStatus.Core.AspNet.Hybrid.csproj
@@ -2,7 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />

--- a/src/ServiceStatus.Core.AspNet/ServiceStatus.Core.AspNet.csproj
+++ b/src/ServiceStatus.Core.AspNet/ServiceStatus.Core.AspNet.csproj
@@ -12,7 +12,15 @@
     <PackageLicenseUrl>https://github.com/ccpgames/ServiceStatus.Core/blob/master/LICENSE</PackageLicenseUrl>
     <Copyright>CCP hf</Copyright>
     <Description>Standardizes and simplifies the addition of a service status endpoint on web sites, or APIs.</Description>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />

--- a/src/ServiceStatus.Core/ServiceStatus.Core.csproj
+++ b/src/ServiceStatus.Core/ServiceStatus.Core.csproj
@@ -12,7 +12,15 @@
     <PackageLicenseUrl>https://github.com/ccpgames/ServiceStatus.Core/blob/master/LICENSE</PackageLicenseUrl>
     <Copyright>CCP hf</Copyright>
     <Description>Standardizes and simplifies the addition of a service status endpoint on web sites, or APIs.</Description>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
